### PR TITLE
UPDATE: Padding on menu links

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -309,7 +309,7 @@ p code + a:visited:hover {
 }
 
 #menu p.links {
-    margin: 0 0 15px;
+    margin: -18px 0 15px;
     border-top: 0;
     text-align: center;
     display: table;


### PR DESCRIPTION
Fixing incorrect padding on menu links, as they were showing incorrectly while browsing (and hard to click)

Screenshot before:
![image](https://user-images.githubusercontent.com/3287543/68994170-4a15cc00-0880-11ea-94db-c78bd02dfdc2.png)


Screenshot after:
![image](https://user-images.githubusercontent.com/3287543/68994190-7b8e9780-0880-11ea-8b02-c6a258846ad3.png)

