### PR TITLE
Make #menu adapt to length of link translations

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -252,7 +252,7 @@ p code + a:visited:hover {
 }
 
 #menu {
-    width: 370px;
+    width: auto;
     border-right: 1px solid #2a2838;
     margin: 0;
     top: 0;


### PR DESCRIPTION
In a few languages, e.g. German, the translation of the action links takes more space than the fixed 370px `#menu` width provides. Setting this width to auto lets the menu automatically adapt: more space for space-saving languages, nice rendering for those with longer words.

370px are a bit better than 347 but not quite fitting: https://github.com/pepa-linha/Adminer-Design-Light/pull/2