### PR TITLE
Fix: Overrides for postgres

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -951,6 +951,28 @@ form p label {
     padding-bottom: 0;
 }
 
+/* Overrides for postgres */  
+  #help.jush-pgsql ~ #menu #tables {
+    top: 320px !important;
+  }
+  
+  #help.jush-pgsql ~ #menu p.links a {
+    margin-top: -10px;
+  }
+  
+  #help.jush-pgsql ~ #menu #tables li:not(.hidden) {
+    display: flex !important;
+    flex-direction: row-reverse !important;
+    justify-content: space-between !important;
+  }
+  
+  .js .hidden,
+  .nojs .jsonly {
+    display: none;
+  }
+  
+  /* End Overrides */
+
 @media print {
     .logout {
         display: none;


### PR DESCRIPTION
**Description**
- Overrides for postgres 
- Addition of hidden class style needed for postgres filter

Doesn't change the existing styles that break other database points, as it only adds the classes if it's pgsql.

### Before
![image](https://user-images.githubusercontent.com/43572006/108591633-c191af80-738f-11eb-94db-059339b1ed59.png)

### After
![image](https://user-images.githubusercontent.com/43572006/108591579-75466f80-738f-11eb-83e6-d2d9e46a503c.png)



