### PR TITLE
Fix Table List Overflow Visible Issue

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -450,6 +450,8 @@ p code + a:visited:hover {
     padding: 0;
     margin: 0 -15px;
     flex: 1;
+	overflow: hidden !important;
+	overflow-y: auto !important;
 }
 
 #tables::-webkit-scrollbar {


### PR DESCRIPTION
### Issue Overview

The `<ul id="tables">` list has some bound JavaScript that changes the list's `overflow` to `visible` when mousing over it.

### Expected Behaviour

The tables list remains scrollable so every table is accessible.

### Current Behaviour

The tables list becomes un-scrollable when mousing over `ul#tables li a.select` which makes the remainder of the tables inaccessible.

### Potential Fix

The light design uses this fix so I simply copied it over: https://github.com/pepa-linha/Adminer-Design-Light/blob/master/adminer.css#L323
