### PR TITLE
Fixed tables listings select is not shown in same line

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -491,6 +491,8 @@ p code + a:visited:hover {
 
 #tables li {
     display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
 }
 
 #tables a {


### PR DESCRIPTION
The "Select" was under the table, fixed that
![image](https://github.com/user-attachments/assets/181a9824-c8c7-4230-96f7-9e26be7ae627)
