### PR TITLE
Support Adminer 4.17.0 odd row highlighing

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -242,8 +242,8 @@ h3 + table,
     box-shadow: inset 2px 0 0 var(--color-table-row-checked-highlight);
 }
 
-.odd th,
-.odd td {
+.odds tbody tr:nth-child(2n) th,
+.odds tbody tr:nth-child(2n) td {
     background: var(--color-table-row-odd);
 }
 


### PR DESCRIPTION
## Overview
This PR updates the CSS for highlighting odd rows in Adminer 4.17.0 by targeting tables with the `.odds` class.
The `.odd` selector has been removed and replaced with a `nth-child(2n)` selector to properly style odd rows in tables with the `.odds` class.

## Changes
Updated `.odd` selector to `.odds tbody tr:nth-child(2n)`.

## Result
Ensures correct odd row highlighting for tables using the `.odds` class in Adminer 4.17.0.