### PR TITLE
Rename to adminer-dark.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Preview](/preview.png "Preview")
 
-**Tested** on MacOS Chrome only (sorry _:-)_), compatible with Adminer 4.8.0
+**Tested** on MacOS Chrome only (sorry _:-)_), compatible with Adminer 5.0.6
 
 ## Changelog
 

--- a/adminer-dark.css
+++ b/adminer-dark.css
@@ -242,8 +242,7 @@ h3 + table,
     box-shadow: inset 2px 0 0 var(--color-table-row-checked-highlight);
 }
 
-.odd th,
-.odd td {
+.odds tbody tr:nth-child(2n) {
     background: var(--color-table-row-odd);
 }
 


### PR DESCRIPTION
This is the way how to tell Adminer 5 that this is a dark theme. Adminer will include its own dark theme by default (useful for new styles in the future) and enable dark syntax highlighting.

This also fixes higlighting odd rows, Adminer doesn't use class="odd" anymore.

See https://php.vrana.cz/adminer-5-0-5.php#d-38764.